### PR TITLE
Add example of deleting property

### DIFF
--- a/docs-content/tile-upgrades.html.md.erb
+++ b/docs-content/tile-upgrades.html.md.erb
@@ -29,6 +29,9 @@ exports.migrate = function(input) {
 
     input.properties['.web_server.example_string']['value'] += '!'; 
     
+    // Delete property 'legacy_property' that's removed in new tile version
+    delete input.properties['.properties.legacy_property'];
+
     // Rename property 'example_port' to 'example_port_renamed',
     // retaining the previous value.
     input.properties['.properties.example_port_renamed'] = 


### PR DESCRIPTION
Just to make it more obvious that properties removed in newer tile versions actually need to be deleted.