### PR TITLE
Fix statement that PCF setup is not required for step 3

### DIFF
--- a/docs-content/development.html.md.erb
+++ b/docs-content/development.html.md.erb
@@ -19,7 +19,7 @@ components much faster. We recommend that you approach development in the follow
 ![Overview](img/tilegenerator.png)
 
 If you follow this approach, you may not have a dependency on a complete
-PCF installation until step 4, and your iterations on the components will
+PCF installation until step 3, and your iterations on the components will
 be much faster than if you attempt to test them through actual deployment
 to PCF.
 


### PR DESCRIPTION
In section 3 (#test-errands) there is this statement "This is the first step for which you will need a complete PCF deployment" which conflicts with the statement "you may not have a dependency on a complete
PCF installation until step 4"