### PR TITLE
Remove backup warning

### DIFF
--- a/docs-content/credhub.html.md.erb
+++ b/docs-content/credhub.html.md.erb
@@ -18,8 +18,6 @@ Tile developers can embed CredHub calls in [manifest snippets](#snippets) and PC
 
 See [Fetching Variable Names and Values](./get-credhub-vars.html) for how to fetch variable names and values using the CredHub API.
 
-<p class="note warning"><strong>WARNING</strong>: CredHub in PCF v1.11.0 does not support backup and restore, so Pivotal only recommends using CredHub for credentials that you can recover from elsewhere after a disaster.</p>
-
 ## <a id="types"></a> CredHub Credential Types
 
 CredHub stores and retrieves the following types of credentials:


### PR DESCRIPTION
CredHub has supported bosh backup and restore [since v1.11.0][1]. See [here](https://docs.pivotal.io/bbr/backup.html) for more details.

[1]:https://github.com/pivotal-cf/credhub-release/tree/1.0.x/jobs/credhub/templates