### PR TITLE
Updates for BOSH links.

### DIFF
--- a/docs-content/tile-generator.html.md.erb
+++ b/docs-content/tile-generator.html.md.erb
@@ -199,6 +199,9 @@ Elastic Runtime use the following format:
   configurable_persistence: true     # optional
   needs_cf_credentials: true         # optional
   auto_services: p-mysql p-redis     # optional
+  consumes:                          # optional
+    redis:
+      from: redis
 ```
 
 For apps that are normally pushed as multiple files (node.js for example)
@@ -229,6 +232,13 @@ for the Elastic Runtime into which they are being deployed. This allows apps and
 services to interact with the Cloud Controller.
 
 The `auto_services` feature is described in more detail below.
+
+`consumes` specifies [BOSH links](https://bosh.io/docs/links.html) to
+consume, and present the hosts and properties from the links as
+environment variables on the app:
+- `<LINK>_HOST`: The address of the first instance of the link.
+- `<LINK>_HOSTS`: A JSON array of the addresses of all instances of the link.
+- `<LINK>_PROPERTIES`: A JSON object of the properties on the link.
 
 #### <a id="brokers"></a> Service Brokers
 
@@ -322,69 +332,35 @@ package definition to include a Redis BOSH release:
 ```
 - name: redis
   type: bosh-release
-  path: resources/redis-12+dev.1.tgz
+  path: resources/redis-13.1.2.tgz
   jobs:
-  - name: redis_leader_z1
+  - name: redis
     templates:
     - name: redis
       release: redis
     memory: 512
     ephemeral_disk: 4096
     persistent_disk: 4096
+    instances: 2
     cpu: 2
-    static_ip: 1
+    static_ip: 0
+    dynamic_ip: 1
+    default_internet_connected: false
     max_in_flight: 1
     properties:
-      network: redis1
-      redis:
-        password: red!s
-  - name: redis_z1
+      password: red!s
+  - name: sanity-tests
     templates:
-    - name: redis
-      release: redis
-    instances: 2
-    memory: 512
-    ephemeral_disk: 4096
-    persistent_disk: 4096
-    cpu: 2
-    static_ip: 1
-    properties:
-      network: redis1
-      redis:
-        master: (( .redis_leader_z1.first_ip ))
-        password: red!s
-  - name: redis_test_slave_z1
-    templates:
-    - name: redis
-      release: redis
-    instances: 1
-    memory: 512
-    ephemeral_disk: 4096
-    persistent_disk: 4096
-    cpu: 2
-    static_ip: 1
-    properties:
-      network: redis1
-      redis:
-        master: (( .redis_leader_z1.first_ip ))
-        password: red!s
-  - name: acceptance-tests
-    templates:
-    - name: acceptance-tests
+    - name: sanity-tests
       release: redis
     lifecycle: errand
     post_deploy: true
-    run_post_deploy_errand_default: when-changed # Could also be: on, off.
+    run_post_deploy_errand_default: when-changed
     memory: 512
     ephemeral_disk: 4096
     persistent_disk: 0
     cpu: 2
     dynamic_ip: 1
-    properties:
-      redis:
-        master: (( .redis_leader_z1.first_ip ))
-        password: red!s
-        slave: (( .redis_test_slave_z1.first_ip ))
 ```
 
 To include [BOSH links](https://bosh.io/docs/links.html) in your


### PR DESCRIPTION
- Add how to consume BOSH links in apps.
- Update redis BOSH release example to avoid Ops Manager IPAM (which
  should now be done with BOSH links).